### PR TITLE
Fix order in blog previous and next buttons

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -22,14 +22,12 @@
             <i class="fa fa-calendar"></i>
             {{ page.date|date("d") }}, {{ page.date|date("M") }}
         </span>
-        
         {% if page.header.author %}
         <span class="list-blog-author">
             <i class="fa fa-user"></i>
             {{ page.header.author }}
         </span>
         {% endif %}
-       
        {% if page.taxonomy.tag %}
         <ul class="tags">
             <i class="fa fa-tag"></i>
@@ -38,7 +36,7 @@
             {% endfor %}
         </ul>
         {% endif %}
-        
+
     </div>
 
     <div class="list-blog-padding">
@@ -62,12 +60,12 @@
     {% if show_prev_next %}
 
         <p class="prev-next">
-            {% if not page.isFirst %}
-                <a class="button" href="{{ page.nextSibling.url }}"><i class="fa fa-chevron-left"></i> Next Post</a>
+            {% if not page.isLast %}
+                <a class="button" href="{{ page.prevSibling.url }}"><i class="fa fa-chevron-left"></i> Previous Post</a>
             {% endif %}
 
-            {% if not page.isLast %}
-                <a class="button" href="{{ page.prevSibling.url }}">Previous Post <i class="fa fa-chevron-right"></i></a>
+            {% if not page.isFirst %}
+                <a class="button" href="{{ page.nextSibling.url }}">Next Post <i class="fa fa-chevron-right"></i></a>
             {% endif %}
         </p>
     {% endif %}


### PR DESCRIPTION
This patch resolves #16 and switches order of the next and previos buttons in the blog section when pagination is enabled.