### PR TITLE
Use query parameter separator from config

### DIFF
--- a/templates/partials/archives.html.twig
+++ b/templates/partials/archives.html.twig
@@ -1,7 +1,7 @@
 <ul class="archives">
 {% for month,items in archives_data %}
     <li>
-    	<a href="{{ base_url }}/archives_month:{{ month|date('M_Y')|lower|e('url') }}">
+    	<a href="{{ base_url }}/archives_month{{ config.system.param_sep }}{{ month|date('M_Y')|lower|e('url') }}">
         <span class="archive_date">{{ month }}</span>
         {% if archives_show_count %}
         <span>({{ items|length }})</span>

--- a/templates/partials/search.html.twig
+++ b/templates/partials/search.html.twig
@@ -7,7 +7,7 @@
         input.on('keypress', function(event) {
             if (event.which == 13 && input.val().length > 3) {
                 event.preventDefault();
-                window.location.href = input.data('search-input') + ':' + input.val();
+                window.location.href = input.data('search-input') + '{{ config.system.param_sep }}' + input.val();
             }
         });
     });

--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -6,7 +6,7 @@ jQuery(document).ready(function($){
     input.on('keypress', function(event) {
         if (event.which == 13 && input.val().length > 3) {
             event.preventDefault();
-            window.location.href = input.data('searchsidebar-input') + ':' + input.val();
+            window.location.href = input.data('searchsidebar-input') + '{{ config.system.param_sep }}' + input.val();
         }
     });
 });


### PR DESCRIPTION
When running Grav on Windows sometimes you need to use `;` instead of `:` as the parameter separator in URLs. Rather than hard-coding this to `:` it should be read from the config.