### PR TITLE
Open social links in new tab

### DIFF
--- a/templates/partials/social.html.twig
+++ b/templates/partials/social.html.twig
@@ -1,7 +1,7 @@
 <ul class="social-icons">
     {% for social in site.social %}
         <li>
-            <a href="{{ social.url }}">
+            <a href="{{ social.url }}" target="_blank">
                 {% if social.icon %}<i class="fa fa-{{ social.icon }}"></i>{% endif %}
             </a>
         </li>


### PR DESCRIPTION
Added target="_blank" to each social icon. This way visitors are not taken away from actual website, but will visit social media sites in separate tab.